### PR TITLE
feat: fetch only available doctors and nurses from Firestore

### DIFF
--- a/eloh-app/components/patients/PatientMeetingSetup.jsx
+++ b/eloh-app/components/patients/PatientMeetingSetup.jsx
@@ -2,7 +2,7 @@
 
 import { db } from "@/db/client";
 import useCurrentUser from "@/hooks/useCurrentUser";
-import { collection, getDocs } from "firebase/firestore";
+import { collection, getDocs, query, where } from "firebase/firestore";
 import { useEffect, useRef, useState } from "react";
 import { FaArrowRight, FaArrowLeft } from "react-icons/fa";
 import ViewMedicalRecords from "../viewMedicalRecords";
@@ -18,34 +18,42 @@ const PatientMeetingSetup = ({ mode, noteOpen, userDoc, setNoteOpen }) => {
   const scrollRef = useRef(null);
 
   useEffect(() => {
-    const fetchDoctors = async () => {
+    const fetchAvailableStaff = async () => {
       setIsLoading(true);
       setError(null);
       try {
-        const doctorsCollection = collection(db, "doctors");
-        const doctorsSnapshot = await getDocs(doctorsCollection);
+        const availableDoctorsQuery = query(
+          collection(db, "doctors"),
+          where("available", "==", true)
+        );
+        const doctorsSnapshot = await getDocs(availableDoctorsQuery);
         const doctorsList = doctorsSnapshot.docs.map((doc) => ({
           id: doc.id,
           ...doc.data(),
         }));
-        const nursesCollection = collection(db, "nurses");
-        const nursesSnapshot = await getDocs(nursesCollection);
+
+        const availableNursesQuery = query(
+          collection(db, "nurses"),
+          where("available", "==", true)
+        );
+        const nursesSnapshot = await getDocs(availableNursesQuery);
         const nursesList = nursesSnapshot.docs.map((doc) => ({
           id: doc.id,
           ...doc.data(),
         }));
-        setDoctors(doctorsList);
-        setNurses(nursesList);
+
+        setDoctors(doctorsList || []);
+        setNurses(nursesList || []);
       } catch (error) {
-        console.error("Error fetching doctors & nurses:", error);
+        console.error("Error fetching available doctors & nurses:", error);
         setDoctors([]);
-        setError("Error fetching doctors & nurses");
+        setError("Error fetching available doctors & nurses");
       } finally {
         setIsLoading(false);
       }
     };
 
-    fetchDoctors();
+    fetchAvailableStaff();
   }, []);
 
   const scroll = (direction) => {


### PR DESCRIPTION
## ✨ Feature: Fetch Only Available Doctors and Nurses

### Description

This update modifies the `useEffect` logic responsible for fetching healthcare personnel (doctors and nurses) from Firestore. Instead of retrieving **all** records, the system now only fetches those marked as **available** (i.e., where `available === true`).

### 🔧 What Changed

- Updated Firestore queries to use `query()` and `where()` to filter on the `available` field.
- Applied the filtering logic to both the `doctors` and `nurses` collections.
- Added a fallback (`setDoctors(doctorsList || [])`) to guard against unexpected null/undefined states.

### 📦 Benefits

- Reduces unnecessary data fetching and improves performance.
- Ensures the UI reflects only actively available staff members.
- Aligns with system expectations for staff availability.

### ✅ QA Notes

- Only available doctors and nurses should now appear in the frontend.
- Confirmed with Firestore that only `available: true` documents are returned.

### 🔍 Firestore Query Used

```js
const doctorsQuery = query(collection(db, "doctors"), where("available", "==", true));
const nursesQuery = query(collection(db, "nurses"), where("available", "==", true));
