### PR TITLE
fix(firestore-rules): refine access control for patients, doctors, and nurses

### DIFF
--- a/eloh-app/app/api/session/route.js
+++ b/eloh-app/app/api/session/route.js
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 
 export async function POST(req) {
   try {
-    const { token, fcmToken } = await req.json();
+    const { token, fcmToken, role } = await req.json();
 
     if (!token) {
       return NextResponse.json({ error: "Missing token" }, { status: 400 });
@@ -16,6 +16,41 @@ export async function POST(req) {
       return NextResponse.json({ error: "Invalid token" }, { status: 401 });
     }
 
+    const uid = decodedToken.uid;
+
+    // 🔥 Determine role by checking both collections
+    const doctorRef = db?.collection("doctors").doc(uid);
+    const nurseRef = db?.collection("nurses").doc(uid);
+    const patientRef = db?.collection("patients").doc(uid);
+    let userRef = null;
+
+    const [doctorSnap, nurseSnap, patientSnap] = await Promise.all([
+      doctorRef.get(),
+      nurseRef.get(),
+      patientRef.get(),
+    ]);
+
+    if (doctorSnap.exists) {
+      userRef = doctorRef;
+    } else if (nurseSnap.exists) {
+      userRef = nurseRef;
+    } else if (patientSnap.exists) {
+      userRef = patientRef;
+    } else {
+      return NextResponse.json(
+        { error: "User not found in any collection" },
+        { status: 404 }
+      );
+    }
+
+    let roleJustSet = false;
+    // 🔐 Set role as a custom claim (only if not already set)
+    if (!decodedToken.role || decodedToken.role !== role) {
+      await auth.setCustomUserClaims(uid, { role });
+      roleJustSet = true;
+    }
+
+    // 🍪 Create session cookie
     const expirationTimeMs = decodedToken.exp * 1000;
     const nowMs = Date.now();
     const expiresIn = expirationTimeMs - nowMs;
@@ -29,7 +64,7 @@ export async function POST(req) {
 
     const sessionCookie = await auth?.createSessionCookie(token, { expiresIn });
 
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     cookieStore.set("session", sessionCookie, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
@@ -37,29 +72,60 @@ export async function POST(req) {
       maxAge: Math.floor(expiresIn / 1000),
     });
 
-    // Optional FCM and profile update
-    if (fcmToken) {
-      const uid = decodedToken.uid;
-      const role = decodedToken.role || "doctor";
-      const userRef = db?.collection(`${role}s`).doc(uid);
-
-      const userSnap = await userRef.get();
-      if (userSnap.exists) {
-        await userRef.set(
-          {
-            fcmToken,
-            online: true,
-            lastLogin: new Date(),
-            updatedAt: new Date(),
-          },
-          { merge: true }
-        );
-      }
+    // 💾 Update FCM and metadata
+    const userSnap = await userRef.get();
+    if (userSnap.exists && fcmToken) {
+      await userRef.set(
+        {
+          fcmToken,
+          online: true,
+          lastLogin: new Date(),
+          updatedAt: new Date(),
+        },
+        { merge: true }
+      );
     }
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, roleJustSet });
   } catch (err) {
     console.error("Session creation error:", err);
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+}
+
+export async function DELETE(req) {
+  try {
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("session")?.value;
+
+    if (sessionCookie) {
+      // Verify session cookie to get UID
+      const decoded = await auth?.verifySessionCookie(sessionCookie, true);
+      const uid = decoded.uid;
+      const role = decoded.role || "patient"; // default fallback
+
+      // Mark user offline
+      const userRef = db.collection(`${role}s`).doc(uid);
+      await userRef.set(
+        {
+          online: false,
+          updatedAt: new Date(),
+        },
+        { merge: true }
+      );
+    }
+
+    // Clear session cookie
+    cookieStore.set("session", "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 0,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("Logout error:", err);
+    return NextResponse.json({ error: "Failed to logout" }, { status: 401 });
   }
 }

--- a/eloh-app/app/dashboard/patient/page.jsx
+++ b/eloh-app/app/dashboard/patient/page.jsx
@@ -22,7 +22,7 @@ const PatientDashboard = () => {
 
   useEffect(() => {
     if (!loading && currentUser?.uid) {
-      const userRef = doc(db, "patients", currentUser.uid);
+      const userRef = doc(db, "patients", currentUser?.uid);
 
       const unsubscribe = onSnapshot(
         userRef,

--- a/eloh-app/components/patients/PatientMeetingSetup.jsx
+++ b/eloh-app/components/patients/PatientMeetingSetup.jsx
@@ -28,7 +28,7 @@ const PatientMeetingSetup = ({ mode, noteOpen, userDoc, setNoteOpen }) => {
   useEffect(() => {
     if (!currentUser?.uid) return;
 
-    const patientRef = doc(db, "patients", currentUser.uid);
+    const patientRef = doc(db, "patients", currentUser?.uid);
     let unsubDoctors = () => {};
     let unsubNurses = () => {};
 

--- a/eloh-app/hooks/useCurrentUser.js
+++ b/eloh-app/hooks/useCurrentUser.js
@@ -47,8 +47,8 @@ const useCurrentUser = () => {
     return () => unsubscribe();
   }, []);
 
-  const createSession = async (user) => {
-    if (!user) return;
+  const createSession = async (user, role) => {
+    if (!user || !role) return;
     const token = await user?.getIdToken();
 
     let fcmToken = null;
@@ -61,12 +61,18 @@ const useCurrentUser = () => {
       console.error("Unable to retrieve FCM token", err);
     }
 
-    await fetch(`${process.env.NEXT_PUBLIC_URL}/api/session`, {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/session`, {
       method: "POST",
-      credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ token, fcmToken }),
+      body: JSON.stringify({ token, fcmToken, role }),
     });
+
+    const data = await res.json();
+    console.log(data, "DATA_XXX");
+    // Force refresh token if role was just set
+    if (data?.roleJustSet) {
+      await user?.getIdToken(true); // ⬅️ Forces the new custom claim
+    }
   };
 
   const handleRegister = async (email, password, role) => {
@@ -78,7 +84,7 @@ const useCurrentUser = () => {
         password
       );
       const user = result.user;
-      await createSession(user);
+      await createSession(user, role);
 
       toast.success("Registered successfully", {
         icon: <AiOutlineCheckCircle className="text-green-600 text-xl" />,
@@ -98,7 +104,7 @@ const useCurrentUser = () => {
     try {
       const result = await signInWithEmailAndPassword(auth, email, password);
       const user = result.user;
-      await createSession(user);
+      await createSession(user, role);
 
       toast.success("Logged in successfully", {
         icon: <AiOutlineCheckCircle className="text-green-600 text-xl" />,


### PR DESCRIPTION
- Updated Firestore security rules to correctly allow patients to read their own documents
- Ensured doctors and nurses have proper access to patient, doctor, and nurse collections
- Restricted updates to earnings-related fields for doctors and nurses by staff roles
- Added clearer role checks to prevent insufficient permission errors during data fetching
- Improved handling of authenticated user roles and Firestore token validation