### PR TITLE
Chat Store & ChatList Improvements

### DIFF
--- a/eloh-app/app/dashboard/doctor/DoctorsCollectionViewer.jsx
+++ b/eloh-app/app/dashboard/doctor/DoctorsCollectionViewer.jsx
@@ -13,6 +13,7 @@ import { db } from "@/db/client";
 import { doc, onSnapshot } from "firebase/firestore";
 import ElohDocChatApp from "@/components/chat-app/ElohDocChatApp";
 import { useUserStore } from "@/hooks/useUserStore";
+import { useChatStore } from "@/hooks/useChatStore";
 
 const DoctorsCollectionViewer = ({ userDoc, patients, userId }) => {
   // State to manage search/filter and modals
@@ -28,6 +29,7 @@ const DoctorsCollectionViewer = ({ userDoc, patients, userId }) => {
   // Ref for scrolling to patient record viewer
   const patientRecordsRef = useRef(null);
   const { fetchUserInfo } = useUserStore();
+  const { unseenCount } = useChatStore();
 
   // Scroll into view when record viewer opens
   useEffect(() => {
@@ -211,9 +213,11 @@ const DoctorsCollectionViewer = ({ userDoc, patients, userId }) => {
                 <div className="relative">
                   <FiMessageCircle size={28} />
                   {/* Unseen messages badge */}
-                  <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold w-4 h-4 flex items-center justify-center rounded-full shadow">
-                    3
-                  </span>
+                  {unseenCount > 0 && (
+                    <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold w-4 h-4 flex items-center justify-center rounded-full shadow animate-pulse">
+                      {unseenCount}
+                    </span>
+                  )}
                 </div>
               </button>
 

--- a/eloh-app/app/dashboard/patient/page.jsx
+++ b/eloh-app/app/dashboard/patient/page.jsx
@@ -16,6 +16,7 @@ import { MdInfo } from "react-icons/md";
 import { FiMessageCircle } from "react-icons/fi";
 import ElohDocChatApp from "@/components/chat-app/ElohDocChatApp";
 import { useUserStore } from "@/hooks/useUserStore";
+import { useChatStore } from "@/hooks/useChatStore";
 
 const PatientDashboard = () => {
   const { currentUser, loading } = useCurrentUser();
@@ -27,6 +28,7 @@ const PatientDashboard = () => {
   const [openChat, setOpenChat] = useState(false);
   const toastShown = useRef(false);
   const { fetchUserInfo } = useUserStore();
+  const { unseenCount } = useChatStore();
 
   useEffect(() => {
     if (!loading && currentUser?.uid) {
@@ -209,9 +211,11 @@ const PatientDashboard = () => {
         <div className="relative">
           <FiMessageCircle size={28} />
           {/* Unseen messages badge */}
-          <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold w-4 h-4 flex items-center justify-center rounded-full shadow">
-            3
-          </span>
+          {unseenCount > 0 && (
+            <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold w-4 h-4 flex items-center justify-center rounded-full shadow animate-pulse">
+              {unseenCount}
+            </span>
+          )}
         </div>
       </button>
 

--- a/eloh-app/app/page.jsx
+++ b/eloh-app/app/page.jsx
@@ -1,7 +1,12 @@
 import LandingPage from "@/components/LandingPage";
+import { COLLECTIONS } from "@/constants";
 import { db, auth } from "@/db/server";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+
+export const metadata = {
+  title: "ElohApp | Home page",
+};
 
 export default async function Home() {
   const session = await cookies();
@@ -11,16 +16,8 @@ export default async function Home() {
     const decoded = await auth?.verifySessionCookie(sessionCookie, true);
     const userId = decoded.uid;
 
-    const collections = [
-      "doctors",
-      "nurses",
-      "patients",
-      "drivers",
-      "customers",
-    ];
-
-    for (const col of collections) {
-      const docSnap = await db.collection(col).doc(userId).get();
+    for (const col of COLLECTIONS) {
+      const docSnap = await db?.collection(col).doc(userId).get();
       if (docSnap.exists) {
         const role = docSnap.data().role;
 
@@ -29,7 +26,7 @@ export default async function Home() {
         if (role === "patient") redirect("/dashboard/patient");
         if (role === "driver") redirect("/dashboard/driver");
         if (role === "customer") redirect("/dashboard/customer");
-        if (!collections.includes(role)) redirect("/");
+        if (!COLLECTIONS.includes(`${role}s`)) redirect("/");
       }
     }
   }

--- a/eloh-app/components/chat-app/List/ChatList.jsx
+++ b/eloh-app/components/chat-app/List/ChatList.jsx
@@ -18,62 +18,88 @@ const ChatList = ({ role }) => {
   const [selectedCategory, setSelectedCategory] = useState("all");
 
   const { currentUser } = useUserStore();
-  const { changeChat } = useChatStore();
+  const { changeChat, updateUnseenCount } = useChatStore();
 
   // Prepare category options for the filter
   const { allOptions, toId } = useMemo(() => {
-    const opts = [{ id: "all", title: "All" }, ...doctorCategories, ...nurseCategories];
+    const opts = [
+      { id: "all", title: "All" },
+      ...doctorCategories,
+      ...nurseCategories,
+    ];
     const map = new Map();
     [...doctorCategories, ...nurseCategories].forEach(({ id, title }) => {
       map.set(id.toLowerCase(), id);
       map.set(title.toLowerCase(), id);
     });
-    return { allOptions: opts, toId: (val) => map.get(String(val || "").toLowerCase()) || null };
+    return {
+      allOptions: opts,
+      toId: (val) => map.get(String(val || "").toLowerCase()) || null,
+    };
   }, []);
 
   useEffect(() => {
     if (!currentUser?.userId) return;
 
-    const unSub = onSnapshot(doc(db, "userchats", currentUser.userId), async (res) => {
-      const items = res.data()?.chats || [];
+    const unSub = onSnapshot(
+      doc(db, "userchats", currentUser.userId),
+      async (res) => {
+        const items = res.data()?.chats || [];
 
-      const promises = items.map(async (item) => {
-        let user = null;
+        const promises = items.map(async (item) => {
+          let user = null;
+          let collectionsToCheck = [];
 
-        // Determine which collections to check based on currentUser's role
-        let collectionsToCheck = [];
-
-        if (currentUser.role === "patient") {
-          const { consultations, consultationType } = currentUser;
-          if (consultations && consultationType !== "none") {
-            if (consultations.doctor > 0) collectionsToCheck.push("doctors");
-            if (consultations.nurse > 0) collectionsToCheck.push("nurses");
+          if (currentUser.role === "patient") {
+            const { consultations, consultationType } = currentUser;
+            if (consultations && consultationType !== "none") {
+              if (consultations.doctor > 0) collectionsToCheck.push("doctors");
+              if (consultations.nurse > 0) collectionsToCheck.push("nurses");
+            }
+          } else if (
+            currentUser.role === "doctor" ||
+            currentUser.role === "nurse"
+          ) {
+            collectionsToCheck.push("patients");
+          } else if (currentUser.role === "driver") {
+            collectionsToCheck.push("customers");
+          } else if (currentUser.role === "customer") {
+            collectionsToCheck.push("drivers");
           }
-        } else if (currentUser.role === "doctor" || currentUser.role === "nurse") {
-          collectionsToCheck.push("patients");
-        } else if (currentUser.role === "driver") {
-          collectionsToCheck.push("customers");
-        } else if (currentUser.role === "customer") {
-          collectionsToCheck.push("drivers");
-        }
 
-        // Check each collection until the user is found
-        for (const col of collectionsToCheck) {
-          const userDocRef = doc(db, col, item.receiverId);
-          const userDocSnap = await getDoc(userDocRef);
+          for (const col of collectionsToCheck) {
+            const userDocRef = doc(db, col, item.receiverId);
+            const userDocSnap = await getDoc(userDocRef);
 
-          if (userDocSnap.exists()) {
-            user = { userId: userDocSnap.id, ...userDocSnap.data() };
-            break;
+            if (userDocSnap.exists()) {
+              user = { userId: userDocSnap.id, ...userDocSnap.data() };
+              break;
+            }
           }
-        }
 
-        return { ...item, user };
-      });
+          return { ...item, user };
+        });
 
-      const chatData = await Promise.all(promises);
-      setChats(chatData.sort((a, b) => b.updatedAt - a.updatedAt));
-    });
+        let chatData = await Promise.all(promises);
+
+        // ✅ Deduplicate by chatId
+        const uniqueChats = new Map();
+        chatData.forEach((c) => {
+          if (c?.user?.userId) {
+            uniqueChats.set(c.user.userId, c);
+          }
+        });
+
+        const finalChats = Array.from(uniqueChats.values()).sort(
+          (a, b) => b.updatedAt - a.updatedAt
+        );
+
+        setChats(finalChats);
+
+        // 🔹 Update global unseen count in Zustand
+        updateUnseenCount(finalChats);
+      }
+    );
 
     return () => unSub();
   }, [currentUser?.userId]);
@@ -81,14 +107,29 @@ const ChatList = ({ role }) => {
   const handleSelect = async (chat) => {
     if (!chat?.user || !currentUser?.userId) return;
 
+    // Map chats to keep only the properties stored in Firestore
     const userChats = chats.map(({ user, ...rest }) => rest);
-    const chatIndex = userChats.findIndex((item) => item.chatId === chat.chatId);
-    userChats[chatIndex].isSeen = true;
+
+    // Deduplicate by receiverId
+    const uniqueChatsMap = new Map();
+    userChats.forEach((c) => {
+      if (c?.receiverId) uniqueChatsMap.set(c.receiverId, c);
+    });
+
+    // Convert back to array
+    const dedupedChats = Array.from(uniqueChatsMap.values());
+
+    // Mark the selected chat as seen
+    const chatIndex = dedupedChats.findIndex((c) => c.chatId === chat.chatId);
+    if (chatIndex !== -1) {
+      dedupedChats[chatIndex].isSeen = true;
+    }
 
     const userChatsRef = doc(db, "userchats", currentUser?.userId);
 
     try {
-      await updateDoc(userChatsRef, { chats: userChats });
+      // Update Firestore with deduplicated chats
+      await updateDoc(userChatsRef, { chats: dedupedChats });
       changeChat(chat.chatId, chat.user);
     } catch (err) {
       console.error(err);
@@ -108,10 +149,14 @@ const ChatList = ({ role }) => {
 
   // Filter chats by search input and category
   const filteredChats = useMemo(() => {
+    // Return all chats if no search input and category is "all"
+    if (!input.trim() && selectedCategory === "all") return chats;
+
     const needle = input.trim().toLowerCase();
 
     return chats.filter((c) => {
       if (!c?.user || !c?.user?.fullName) return false;
+
       const name = c.user.fullName.toLowerCase();
       const matchesInput = !needle || name.includes(needle);
 
@@ -141,7 +186,11 @@ const ChatList = ({ role }) => {
           title="Add new users"
           onClick={() => setAddMode((prev) => !prev)}
         >
-          {addMode ? <FiMinus className="w-5 h-5" /> : <FiPlus className="w-5 h-5" />}
+          {addMode ? (
+            <FiMinus className="w-5 h-5" />
+          ) : (
+            <FiPlus className="w-5 h-5" />
+          )}
         </div>
       </div>
 
@@ -158,8 +207,11 @@ const ChatList = ({ role }) => {
         <div
           key={chat?.chatId}
           onClick={() => handleSelect(chat)}
-          className={`flex items-center gap-5 p-5 cursor-pointer border-b border-gray-600 transition-colors ${chat?.isSeen ? "bg-transparent hover:bg-gray-800" : "bg-blue-600/50 hover:bg-blue-500/60"
-            }`}
+          className={`flex items-center gap-5 p-5 cursor-pointer border-b border-gray-600 transition-colors ${
+            chat?.isSeen
+              ? "bg-transparent hover:bg-gray-800"
+              : "bg-blue-600/50 hover:bg-blue-500/60"
+          }`}
         >
           {/* Avatar */}
           {chat.user?.photoUrl ? (
@@ -177,7 +229,9 @@ const ChatList = ({ role }) => {
           {/* Username & Last Message */}
           <div className="flex flex-col gap-2">
             <span className="font-medium">
-              {chat.user.blocked.includes(currentUser?.userId || "") ? "User" : getDisplayName(chat.user)}
+              {chat.user.blocked.includes(currentUser?.userId || "")
+                ? "User"
+                : getDisplayName(chat.user)}
             </span>
             <p className="text-sm font-light truncate">{chat?.lastMessage}</p>
           </div>

--- a/eloh-app/constants/index.js
+++ b/eloh-app/constants/index.js
@@ -243,6 +243,9 @@ export const STAFF_EARNING_PER_CONSULTATION = CONSULTATION_FEE - PLATFORM_FEE;
  */
 export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * Eloh Doc user collections
+ */
 export const COLLECTIONS = [
   "customers",
   "doctors",

--- a/eloh-app/helpers/toastHelper.js
+++ b/eloh-app/helpers/toastHelper.js
@@ -1,4 +1,3 @@
-// toastHelper.js
 import { toast } from "react-toastify";
 
 const baseOptions = {
@@ -9,6 +8,13 @@ const baseOptions = {
   theme: "light",
 };
 
+/**
+ * Show a green success toast notification.
+ *
+ * @param {string} msg - The success message to display.
+ * @param {number} [duration=3000] - Duration (ms) before toast auto-closes.
+ * @returns {import("react-toastify").Id} The toast ID.
+ */
 export const toastSuccess = (msg, duration = 3000) =>
   toast.success(msg, {
     ...baseOptions,
@@ -16,6 +22,13 @@ export const toastSuccess = (msg, duration = 3000) =>
     className: "bg-green-500 text-white font-semibold shadow-lg rounded-md",
   });
 
+/**
+ * Show a red error toast notification.
+ *
+ * @param {string} msg - The error message to display.
+ * @param {number} [duration=3000] - Duration (ms) before toast auto-closes.
+ * @returns {import("react-toastify").Id} The toast ID.
+ */
 export const toastError = (msg, duration = 3000) =>
   toast.error(msg, {
     ...baseOptions,
@@ -23,6 +36,13 @@ export const toastError = (msg, duration = 3000) =>
     className: "bg-red-500 text-white font-semibold shadow-lg rounded-md",
   });
 
+/**
+ * Show a blue info toast notification.
+ *
+ * @param {string} msg - The informational message to display.
+ * @param {number} [duration=3000] - Duration (ms) before toast auto-closes.
+ * @returns {import("react-toastify").Id} The toast ID.
+ */
 export const toastInfo = (msg, duration = 3000) =>
   toast.info(msg, {
     ...baseOptions,

--- a/eloh-app/hooks/useChatStore.js
+++ b/eloh-app/hooks/useChatStore.js
@@ -9,6 +9,7 @@ import { useUserStore } from "./useUserStore";
  * - `user`: the chat partner (null if blocked or no active chat)
  * - `isCurrentUserBlocked`: true if the chat partner has blocked the current user
  * - `isReceiverBlocked`: true if the current user has blocked the partner
+ * - `unseenCount`: number of unseen messages
  *
  * Actions:
  * - `changeChat(chatId, user)`: Switch to a new chat. Handles blocked states automatically.
@@ -27,6 +28,7 @@ export const useChatStore = create((set) => ({
   user: null,
   isCurrentUserBlocked: false,
   isReceiverBlocked: false,
+  unseenCount: 0,
 
   changeChat: (chatId, user) => {
     const currentUser = useUserStore.getState().currentUser;
@@ -64,6 +66,16 @@ export const useChatStore = create((set) => ({
       chatId: null,
       user: null,
     });
+  },
+  /**
+   * Update the global unseen count from an array of chats
+   */
+  updateUnseenCount: (chats) => {
+    if (!chats) {
+      set({ unseenCount: 0 });
+    }
+    const count = chats.reduce((acc, chat) => (chat.isSeen ? acc : acc + 1), 0);
+    set({ unseenCount: count });
   },
 
   resetChat: () => {

--- a/eloh-app/hooks/useChatStore.js
+++ b/eloh-app/hooks/useChatStore.js
@@ -1,6 +1,27 @@
 import { create } from "zustand";
 import { useUserStore } from "./useUserStore";
 
+/**
+ * Zustand store for managing chat state between users.
+ *
+ * This store keeps track of:
+ * - `chatId`: the currently active chat
+ * - `user`: the chat partner (null if blocked or no active chat)
+ * - `isCurrentUserBlocked`: true if the chat partner has blocked the current user
+ * - `isReceiverBlocked`: true if the current user has blocked the partner
+ *
+ * Actions:
+ * - `changeChat(chatId, user)`: Switch to a new chat. Handles blocked states automatically.
+ * - `changeBlock()`: Toggle whether the current user has blocked the partner.
+ * - `setChatId()`: Clear the current chat ID and partner without resetting block states.
+ * - `resetChat()`: Reset all chat state back to initial defaults.
+ * - `deleteChat(chatIdToDelete)`: If the deleted chat is the active one, reset state; otherwise no change.
+ *
+ * Notes:
+ * - The store checks blocking logic by referencing `useUserStore`.
+ * - If the partner has blocked the current user, the `user` field is set to null
+ *   so the UI can hide or disable interactions.
+ */
 export const useChatStore = create((set) => ({
   chatId: null,
   user: null,

--- a/eloh-app/hooks/useUserStore.js
+++ b/eloh-app/hooks/useUserStore.js
@@ -1,17 +1,33 @@
 import { create } from "zustand";
 
+/**
+ * Zustand store for managing the authenticated user's state.
+ *
+ * State:
+ * - `currentUser`: The currently logged-in user object, or `null` if none.
+ * - `isLoading`: Indicates whether user data is being loaded.
+ *
+ * Actions:
+ * - `fetchUserInfo(userDoc)`: Asynchronously updates the store with user data.
+ *    - If `userDoc` is missing or has no `userId`, resets `currentUser` to null.
+ *    - Otherwise, sets `currentUser` with the provided data, spreading all fields
+ *      from `userDoc` and ensuring `id` is mapped from `userDoc.userId`.
+ *    - Always sets `isLoading` to `false` once finished.
+ *
+ * Notes:
+ * - Error handling is included: if something fails during fetch, the store
+ *   resets `currentUser` to `null` and sets `isLoading` to `false`.
+ */
 export const useUserStore = create((set) => ({
   currentUser: null,
   isLoading: true,
   fetchUserInfo: async (userDoc) => {
-    // If no userDoc is provided, reset the user and stop loading
     if (!userDoc || !userDoc.userId) {
       set({ currentUser: null, isLoading: false });
       return;
     }
 
     try {
-      // Map userId to id
       set({
         currentUser: { id: userDoc.userId, ...userDoc },
         isLoading: false,

--- a/eloh-app/lib/getMessageDate.js
+++ b/eloh-app/lib/getMessageDate.js
@@ -1,3 +1,19 @@
+/**
+ * Utility function to normalize different timestamp formats into a JavaScript Date object.
+ *
+ * Supported input types:
+ * - `undefined` or `null` → returns the current date/time.
+ * - `number` → treated as a UNIX timestamp in milliseconds.
+ * - `string` → parsed into a Date using the native Date constructor.
+ * - Firestore `Timestamp` (objects with `.toDate()` method) → converted to a Date.
+ * - Already a `Date` instance → returned as-is.
+ *
+ * Fallback:
+ * - If input type is unrecognized, returns the current date/time.
+ *
+ * @param {number|string|Date|{toDate: Function}|null|undefined} createdAt - The input value representing a date or timestamp.
+ * @returns {Date} A normalized JavaScript Date object.
+ */
 export const getMessageDate = (createdAt) => {
   if (!createdAt) return new Date();
   if (typeof createdAt === "number") return new Date(createdAt);

--- a/eloh-app/lib/postMeetingUpdates.js
+++ b/eloh-app/lib/postMeetingUpdates.js
@@ -1,6 +1,4 @@
-import { doc, getDoc, updateDoc, increment, setDoc } from "firebase/firestore";
-import { auth, db } from "@/db/client";
-import { PLATFORM_FEE, STAFF_EARNING_PER_CONSULTATION } from "@/constants";
+import { auth } from "@/db/client";
 
 /**
  * Handles end of a meeting:

--- a/eloh-app/lib/sendNotificationToStaff.js
+++ b/eloh-app/lib/sendNotificationToStaff.js
@@ -1,6 +1,41 @@
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/db/client";
 
+/**
+ * Sends a push notification to a doctor and optionally creates a call record in Firestore.
+ *
+ * Workflow:
+ * 1. Makes a POST request to the `/api/notify-doctor` endpoint with doctor and patient IDs,
+ *    plus any additional payload data.
+ * 2. If the response is not OK, throws an error with the returned error message.
+ * 3. If the payload includes a `caller` object, creates a `calls/{doctorId_patientId}` document
+ *    in Firestore to represent an active ringing call.
+ *
+ * Firestore call document structure:
+ * {
+ *   type: "video-call",
+ *   status: "ringing",
+ *   doctorId: string,
+ *   patientId: string,
+ *   caller: {
+ *     id: string,
+ *     name: string,
+ *     photoUrl: string
+ *   },
+ *   createdAt: serverTimestamp(),
+ *   updatedAt: serverTimestamp()
+ * }
+ *
+ * @param {string} doctorId - The ID of the doctor to notify.
+ * @param {string} patientId - The ID of the patient initiating the action.
+ * @param {object} [payload={}] - Additional data to send with the notification.
+ *   @param {object} [payload.caller] - Caller info if initiating a call.
+ *   @param {string} payload.caller.id - Caller user ID.
+ *   @param {string} payload.caller.name - Caller display name.
+ *   @param {string} [payload.caller.photoUrl] - Caller profile picture URL (defaults to `/images/default_avatar.jpg`).
+ *
+ * @returns {Promise<void>} Resolves when the notification is sent (and Firestore updated if applicable).
+ */
 export const sendNotificationToDoctor = async (
   doctorId,
   patientId,


### PR DESCRIPTION
# Pull Request: Chat Store & ChatList Improvements

## Summary
This PR introduces several improvements to the chat functionality:

1. **Zustand Chat Store Enhancements**  
   - Added a global `unseenCount` state to track total unseen messages across all chats.  
   - Added `updateUnseenCount(chats)` action to update the `unseenCount` whenever the chat list changes.  
   - Refactored `getTotalUnseen` into the reactive `unseenCount` for global access.  
   - Maintained existing actions: `changeChat`, `changeBlock`, `setChatId`, `resetChat`, `deleteChat`.

2. **ChatList Component Improvements**  
   - Fixed duplication issues in the chat list by deduplicating based on `userId`.  
   - Now returns **all chats by default**, only filtering by name or category if search input or category filter is applied.  
   - Automatically updates the global `unseenCount` whenever the chat list is updated from Firestore.  
   - Improved handling of blocked users and chat selection.  
   - Cleaned up logic for category filtering and search input.

3. **General Enhancements**  
   - Ensured `unseenCount` is reactive and can be accessed from any component across the app.  
   - Optimized deduplication logic using `Map` for better performance and correctness.  
   - Updated JS Doc for the `useChatStore` store for clarity.


## Notes
- `unseenCount` is now the single source of truth for all unseen messages.  
- The `ChatList` component automatically triggers updates to `unseenCount` whenever chats are fetched or changed.  
- Future enhancements can include per-chat unseen message badges using the same logic.

